### PR TITLE
Added .travis.yml for testing on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: php
+php:
+  - 5.3
+branches:
+  only:
+    - dev
+    - master
+script:
+    - cd tests
+    - ./runtests


### PR DESCRIPTION
This PR includes a .travis.yml confuguration file which enables testing on Travis-CI. See https://travis-ci.org for more information.

To enable this you will need to set up the Travis-CI hook on GitHub.
