### PR TITLE
Fix the validation of signed requests.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1251,6 +1251,7 @@ class VGS_Client {
      */
     public function parseSignedRequest($signed_request) {
         list($encoded_sig, $payload) = explode('.', $signed_request, 2);
+        $data = json_decode(self::base64UrlDecode($payload), true);
         $algorithm = strtoupper($data['algorithm']);
         return $this->validateAndDecodeSignedRequest($encoded_sig, $payload, $algorithm);
     }
@@ -1267,6 +1268,7 @@ class VGS_Client {
         }
         return $ret;
     }
+
     public function createHash($data) {
         $string = $this->recursiveHash($data);
         $secret = $this->getClientSignSecret();
@@ -1276,10 +1278,11 @@ class VGS_Client {
     public function validateAndDecodeSignedRequest($encoded_signature, $payload, $algorithm = 'HMAC-SHA256') {
         $sig = self::base64UrlDecode($encoded_signature);
         $data = json_decode(self::base64UrlDecode($payload), true);
+        $string = $this->recursiveHash($data);
 
         switch ($algorithm) {
             case 'HMAC-SHA256' :
-                $expected_sig = hash_hmac('sha256', $payload, $this->getClientSignSecret(), true);
+                $expected_sig = hash_hmac('sha256', $string, $this->getClientSignSecret(), true);
 
                 // check sig
                 if ($sig !== $expected_sig) {

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -1,8 +1,9 @@
 <?php
 
 class ClientTest extends PHPUnit_Framework_TestCase {
+    private $config;
 
-    public function testConfig() {
+    public function setUp() {
         $SPID_CREDENTIALS = array(
             VGS_Client::CLIENT_ID       => '4cf36fa274dea2117e030000',//4d06920474dea26227070000',//
             VGS_Client::CLIENT_SECRET   => 'foobar',
@@ -15,9 +16,26 @@ class ClientTest extends PHPUnit_Framework_TestCase {
             VGS_Client::API_VERSION     => 2,
             VGS_Client::PRODUCTION      => true,
         );
-        $client = new VGS_Client($SPID_CREDENTIALS);
+        $this->client = new VGS_Client($SPID_CREDENTIALS);
+    }
+
+    public function testClient() {
         $expected = 'https://payment.schibsted.no';
-        $result   = $client->getServerURL();
+        $result   = $this->client->getServerURL();
         $this->assertEquals($expected, $result);
+    }
+
+    public function testParseSignedRequest() {
+        $request = array(
+            'algorithm' => 'HMAC-SHA256',
+            0 => 'payload',
+        );
+
+        $payload = rtrim(strtr(base64_encode(json_encode($request)), '+/', '-_'), '=');
+        $hash = $this->client->createHash($request);
+
+        $signedRequest = sprintf('%s.%s', $hash, $payload);
+
+        $this->assertSame($request, $this->client->parseSignedRequest($signedRequest));
     }
 }


### PR DESCRIPTION
Fix the signed request validation and provide a unit test which ensures it works. It could be solved better since it now decodes the payload twice, but I didn't want to break the existing public API.
