### PR TITLE
Fix typo in setContextClientID()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -340,7 +340,7 @@ class VGS_Client {
      * @param string $context_client_id the Client ID
      */
     public function setContextClientID($context_client_id) {
-        $this->context_lient_id = $context_client_id;
+        $this->context_client_id = $context_client_id;
     }
 
     /**


### PR DESCRIPTION
It set's the property "context_lient_id", instead of "context_client_id" which the getter uses.
