### PR TITLE
Disable DNS-cache for libcurl

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -65,6 +65,7 @@ class VGS_Client {
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => false,
             CURLOPT_SSL_VERIFYHOST => false,
+            CURLOPT_DNS_CACHE_TIMEOUT => 0,
             CURLOPT_TIMEOUT => 30,
             CURLOPT_USERAGENT => 'spid-php-2.3'
      );


### PR DESCRIPTION
When SPID moved to Amazon and started to use Amazon Elastic Loadbalancer it broke a lot of our serverside scripts. libcurl has it's own builtin DNS-cache for each thread that is set to 120 Seconds. In addition it has a bug that are present in quite a lot of the older libcurl-installations that never times out the dns-cache if the thread is very busy
