### PR TITLE
Add more robust HMAC check

### DIFF
--- a/examples/callback/index.php
+++ b/examples/callback/index.php
@@ -37,7 +37,7 @@ function parse_signed_request($signed_request, $secret) {
 
   // check sig
   $expected_sig = hash_hmac('sha256', $payload, $secret, true);
-  if ($sig !== $expected_sig) {
+  if (!hash_equals($sig, $expected_sig)) {
     return null;
   }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -1406,7 +1406,7 @@ class VGS_Client {
                 $expected_sig = hash_hmac('sha256', $payload, $this->getClientSignSecret(), true);
 
                 // check sig
-                if ($sig !== $expected_sig) {
+                if (!hash_equals($sig, $expected_sig)) {
                     self::errorLog('Bad Signed JSON signature!');
                     return null;
                 }


### PR DESCRIPTION
Note that `hash_equals` was added in PHP 5.6.0.